### PR TITLE
Asutliff/live cluster changes

### DIFF
--- a/Ansible/K8s-Ansible/playbook.install.yaml
+++ b/Ansible/K8s-Ansible/playbook.install.yaml
@@ -56,6 +56,7 @@
     kube_user: "asutliff"
     kube_config_path: "/home/{{ kube_user }}/.kube/config"
     default_config: true
+    new_user_config: false
     flannel: true #set the name of the CNI plugin you want to use to true, currently supports only flannel
   roles:
     - cluster_init
@@ -121,6 +122,7 @@
     kube_user: "asutliff"
     kube_config_path: "/home/{{ kube_user }}/.kube/config"
     new_user_config: true
+    default_user_config: false
   roles:
     - kubeconfig
 

--- a/Ansible/K8s-Ansible/playbook.install.yaml
+++ b/Ansible/K8s-Ansible/playbook.install.yaml
@@ -33,13 +33,13 @@
     kubeadm_version: 1.25.0-00
     kubectl_version: 1.25.0-00
     kubelet_version: 1.25.0-00
-    ufw_rules: item
-    with_items: 
-     ufw_rules: "{{ ufw_rules }}"
+    # ufw_rules: item
+    # with_items: 
+    #  ufw_rules: "{{ ufw_rules }}"
   roles:
     - kernel_config
     - repositories
-    - ansible-ufw
+    # - ansible-ufw
     - kubeadm
     - kubelet
     - kubectl

--- a/Ansible/K8s-Ansible/playbook.install.yaml
+++ b/Ansible/K8s-Ansible/playbook.install.yaml
@@ -78,7 +78,6 @@
   - name: Generate an OpenSSL private key with the default values (4096 bits, RSA)
     community.crypto.openssl_privatekey:
       path: /etc/ssl/private/ansible.com.pem
-      cipher: auto
   - name: Generate an OpenSSL Certificate Signing Request
     community.crypto.openssl_csr:
       path: /etc/ssl/csr/ansible.csr

--- a/Ansible/K8s-Ansible/roles/add_node/tasks/main.yml
+++ b/Ansible/K8s-Ansible/roles/add_node/tasks/main.yml
@@ -2,10 +2,16 @@
 # tasks file for add-node
 - name: Copy Join Command to Nodes
   copy:
-    src: "/tmp/join-command.sh"
+    src: "/tmp/k8s-controlplane/tmp/join-command.sh"
     dest: "/tmp"
     mode: ugo=rwx
   tags: cluster-init
 
 - name: Join Node to Cluster
   command: sh /tmp/join-command.sh
+
+- name: Clean Up temp files for join command
+  file:
+    path: /tmp/join-command.sh
+    state: absent
+  changed_when: false

--- a/Ansible/K8s-Ansible/roles/add_node/tasks/main.yml
+++ b/Ansible/K8s-Ansible/roles/add_node/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: Copy Join Command to Nodes
   copy:
     src: "/tmp/join-command.sh"
-    dest: "/tmp/join-command.sh"
+    dest: "/tmp"
     mode: ugo=rwx
   tags: cluster-init
 

--- a/Ansible/K8s-Ansible/roles/cluster_init/tasks/controlplane.yaml
+++ b/Ansible/K8s-Ansible/roles/cluster_init/tasks/controlplane.yaml
@@ -21,4 +21,4 @@
 - name: Fetch join command back to local host
   fetch:
     src: /tmp/join-command.sh
-    dest: /tmp/join-command.sh
+    dest: /tmp

--- a/Ansible/K8s-Ansible/roles/cluster_init/tasks/controlplane.yaml
+++ b/Ansible/K8s-Ansible/roles/cluster_init/tasks/controlplane.yaml
@@ -5,7 +5,7 @@
     --node-name="{{ host_name }}" \
     --pod-network-cidr="{{ pod_network_cidr }}"
 #need to change variables
-  tags: cluster-init
+  tags: adm-init
 
 - name: Generate join command
   command: kubeadm token create --print-join-command

--- a/Ansible/K8s-Ansible/roles/kubeconfig/tasks/main.yml
+++ b/Ansible/K8s-Ansible/roles/kubeconfig/tasks/main.yml
@@ -10,16 +10,16 @@
 - name: Fetch default kube configuration
   fetch:
     src: /etc/kubernetes/admin.conf
-    dest: /tmp/kubernetes/admin.conf
-    when: default_config
+    dest: /tmp
+  when: default_config
 
 - name: Create default kubeconfig for on-master user
   copy:
-    src: /tmp/kubernetes/admin.conf
+    src: /tmp/{{ ansible_host }}/etc/kubernetes/admin.conf
     dest: "{{ kube_config_path }}"
     owner: "{{ kube_user }}"
     group: "{{ kube_user }}"
-    when: default_config
+  when: default_config
 
 - name: Create new user kubeconfig on external machine
   command: kubectl config set-credentials cluster-admin --client-certificate="{{ certificate_path }}" --client-key="{{ key_path }}" --embed-certs=true

--- a/Ansible/K8s-Ansible/roles/kubeconfig/tasks/main.yml
+++ b/Ansible/K8s-Ansible/roles/kubeconfig/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - name: Create default kubeconfig for on-master user
   copy:
-    src: /etc/kubernetes/admin.conf
+    remote_src: /etc/kubernetes/admin.conf
     dest: "{{ kube_config_path }}"
     owner: "{{ kube_user }}"
     group: "{{ kube_user }}"

--- a/Ansible/K8s-Ansible/roles/kubeconfig/tasks/main.yml
+++ b/Ansible/K8s-Ansible/roles/kubeconfig/tasks/main.yml
@@ -7,9 +7,15 @@
     owner: "{{ kube_user }}"
     group: "{{ kube_user }}"
 
+- name: Fetch default kube configuration
+  fetch:
+    src: /etc/kubernetes/admin.conf
+    dest: /tmp/kubernetes/admin.conf
+    when: default_config
+
 - name: Create default kubeconfig for on-master user
   copy:
-    remote_src: /etc/kubernetes/admin.conf
+    src: /tmp/kubernetes/admin.conf
     dest: "{{ kube_config_path }}"
     owner: "{{ kube_user }}"
     group: "{{ kube_user }}"


### PR DESCRIPTION
changes made to make the playbook work with the live cluster instead of the original version where the ansible controller lived on the same node as the k8s controller
fixes include
- fixing issues with join command pathing
- adding a separate tag to be able to skip kubeadm-init once its been initialized once
- fetched default kubeconfig to ansible controller first before setting it on master node