### PR TITLE
Asutliff/debug csr

### DIFF
--- a/Ansible/K8s-Ansible/playbook.install.yaml
+++ b/Ansible/K8s-Ansible/playbook.install.yaml
@@ -77,7 +77,7 @@
   tasks:
   - name: Generate an OpenSSL private key with the default values (4096 bits, RSA)
     community.crypto.openssl_privatekey:
-      path: ~/ansible.pem
+      path: ~/ansible.key
   - name: Generate an OpenSSL Certificate Signing Request
     community.crypto.openssl_csr:
       path: ~/ansible.csr
@@ -136,7 +136,7 @@
     kube_user: "asutliff"
     kube_config_path: "/home/{{ kube_user }}/.kube/config"
     certificate_path: "/tmp/k8s-controlplane/ansible.crt"
-    key_path: "home/{{ kube_user }}/ansible.pem"
+    key_path: "/home/{{ kube_user }}/ansible.key"
     new_user_config: true
     default_config: false
   roles:

--- a/Ansible/K8s-Ansible/playbook.install.yaml
+++ b/Ansible/K8s-Ansible/playbook.install.yaml
@@ -77,42 +77,53 @@
   tasks:
   - name: Generate an OpenSSL private key with the default values (4096 bits, RSA)
     community.crypto.openssl_privatekey:
-      path: /etc/ssl/private/ansible.com.pem
+      path: ~/ansible.pem
   - name: Generate an OpenSSL Certificate Signing Request
     community.crypto.openssl_csr:
-      path: /etc/ssl/csr/ansible.csr
-      privatekey_path: /etc/ssl/private/ansible.pem
+      path: ~/ansible.csr
+      privatekey_path: ~/ansible.pem
       common_name: asutliff
       organization_name: system:masters
+  tags: csr
 
 - hosts: controlplane_nodes #figure out how to limit this to only a single host
+  become_user: asutliff
   tasks:
   - name: Copy CSR to Controleplane
     copy:
-      src: /etc/ssl/csr/ansible.csr
-      dest: ~/ansible.csr
+      src: ~/ansible.csr
+      dest: ~/
   - name: Convert CSR into Usable format
-    command: cat ansible.csr | base64 | tr -d "\n"
+    shell: |
+      cat ansible.csr | base64 | tr -d '\n'
     register: ansible_csr
   - name: Create CSR Kubernetes Object
-    command: |
-      cat <<EOF | kubectl create -f 
-      apiVersion: certificates.k8s.io/v1beta
+    shell: |
+      cat <<EOF | kubectl create -f -
+      apiVersion: certificates.k8s.io/v1
       kind: CertificateSigningRequest
       metadata:
         name: asutliff
       spec:
-        groups:
-        - system: authenticated
-        uses:
+        signerName: kubernetes.io/kube-apiserver-client
+        usages:
         - digital signature
         - key encipherment
-        - server auth
+        - server auth 
         request:
-          "{{ ansible_csr.stout_lines[0] }}"
+          "{{ ansible_csr.stdout }}"
       EOF
   - name: Sign CSR
     command: kubectl certificate approve asutliff
+  - name: Output Signed CSR Certificate
+    shell: |
+      "kubectl get csr  -o yaml | grep -e '^    certificate:' | sed 's/    certificate://'"
+    register: signed_cert
+  - name: Copy Signed CSR Certificate to Controller
+    fetch:
+      content: "{{ signed_cert.stdout }}"
+      dest: ~/ansible.crt
+  tags: csr
 
 - hosts: ansible_controller
   become: yes
@@ -120,8 +131,10 @@
   vars:
     kube_user: "asutliff"
     kube_config_path: "/home/{{ kube_user }}/.kube/config"
+    certificate_path: "home/{{ kube_user }}/ansible.pem"
+    key_path: "home/{{ kube_user }}/ansible.pem"
     new_user_config: true
-    default_user_config: false
+    default_config: false
   roles:
     - kubeconfig
 

--- a/Ansible/K8s-Ansible/playbook.install.yaml
+++ b/Ansible/K8s-Ansible/playbook.install.yaml
@@ -83,7 +83,7 @@
       path: ~/ansible.csr
       privatekey_path: ~/ansible.pem
       common_name: asutliff
-      organization_name: system:masters
+      organization_name: system:authenticated
   tags: csr
 
 - hosts: controlplane_nodes #figure out how to limit this to only a single host
@@ -109,7 +109,7 @@
         usages:
         - digital signature
         - key encipherment
-        - server auth 
+        - client auth
         request:
           "{{ ansible_csr.stdout }}"
       EOF
@@ -117,7 +117,7 @@
     command: kubectl certificate approve asutliff
   - name: Output Signed CSR Certificate
     shell: |
-      "kubectl get csr  -o yaml | grep -e '^    certificate:' | sed 's/    certificate://'"
+      kubectl get csr asutliff -o yaml | grep -e '^    certificate:' | sed 's/    certificate://' | base64 --decode
     register: signed_cert
   - name: Copy Signed CSR Certificate to Controller
     fetch:

--- a/Ansible/K8s-Ansible/playbook.install.yaml
+++ b/Ansible/K8s-Ansible/playbook.install.yaml
@@ -117,12 +117,16 @@
     command: kubectl certificate approve asutliff
   - name: Output Signed CSR Certificate
     shell: |
-      kubectl get csr asutliff -o yaml | grep -e '^    certificate:' | sed 's/    certificate://' | base64 --decode
+      kubectl get csr asutliff -o yaml | grep -e '^  certificate:' | sed 's/certificate://' | tr -d [:space:] | base64 --decode
     register: signed_cert
-  - name: Copy Signed CSR Certificate to Controller
-    fetch:
+  - name: Copy Signed CSR Certificate to master
+    copy:
       content: "{{ signed_cert.stdout }}"
       dest: ~/ansible.crt
+  - name: Copy Signed CSR Certificate to Controller
+    fetch:
+      src: ansible.crt
+      dest: /tmp
   tags: csr
 
 - hosts: ansible_controller
@@ -131,7 +135,7 @@
   vars:
     kube_user: "asutliff"
     kube_config_path: "/home/{{ kube_user }}/.kube/config"
-    certificate_path: "home/{{ kube_user }}/ansible.pem"
+    certificate_path: "/tmp/k8s-controlplane/ansible.crt"
     key_path: "home/{{ kube_user }}/ansible.pem"
     new_user_config: true
     default_config: false

--- a/Ansible/K8s-Ansible/roles/kubeconfig/tasks/main.yml
+++ b/Ansible/K8s-Ansible/roles/kubeconfig/tasks/main.yml
@@ -23,6 +23,6 @@
 
 - name: Create new user kubeconfig on external machine
   shell: |
-    sudo kubectl config set-credentials cluster-admin --client-certificate="{{ certificate_path }}" --client-key="{{ key_path }}" --embed-certs=true
+    sudo kubectl config set-credentials {{ kube_user }} --client-certificate="{{ certificate_path }}" --client-key="{{ key_path }}" --embed-certs=true
   # also need to configure the cluster in the kubeconfig, and set the current context
   when: new_user_config

--- a/Ansible/K8s-Ansible/roles/kubeconfig/tasks/main.yml
+++ b/Ansible/K8s-Ansible/roles/kubeconfig/tasks/main.yml
@@ -22,5 +22,7 @@
   when: default_config
 
 - name: Create new user kubeconfig on external machine
-  command: kubectl config set-credentials cluster-admin --client-certificate="{{ certificate_path }}" --client-key="{{ key_path }}" --embed-certs=true
+  shell: |
+    sudo kubectl config set-credentials cluster-admin --client-certificate="{{ certificate_path }}" --client-key="{{ key_path }}" --embed-certs=true
+  # also need to configure the cluster in the kubeconfig, and set the current context
   when: new_user_config


### PR DESCRIPTION
csr now gets generated correctly, signed by kubernetes certificates api, and passed back to main ansible controller to be integrated into local kubeconfig